### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Luca Sasselli
 maintainer=Luca Sasselli
 sentence=A library for setting commands via serial stream.
 paragraph=SimpleCommands is a small library that allows the user to setup and issue commands via serial stream.
-category=Serial
+category=Communication
 url=https://github.com/lucasax
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Serial' in library SimpleCommands is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format